### PR TITLE
Basic Sentinel support

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -704,7 +704,7 @@ function read_from_cache(self)
             local header = cache_parts[i]:sub(3)
             if header then
                 if header:sub(2,2) == ':' then
-                    -- Multiple headers, we also need to preserve the order?
+                    -- Multiple headers are represented as a table of values
                     local index = tonumber(header:sub(1,1))
                     header = header:sub(3)
                     if res.header[header] == nil then


### PR DESCRIPTION
Makes ledge sentinel aware if enabled.
Ledge will use the configured sentinel instance and master name to retrieve the current redis master instance when doing write operations (e.g. save_to_cache and delete_from_cache).

For read operations the default configured redis instance is used and sentinel is not consulted.
This keeps latency to a minimum on the fast path (cache hits) and adds a minimum of latency to the slow path.

The likelihood of the local redis instance being down and the entire server not being down seems low so the real advantage from this feature is to enable failover of a redis master instance.

Adding support for picking a new slave instance if unable to connect to the local instance adds complexity to the code for little practical gain but has been prototyped and could be added in the future if needed.

Also reduced the default redis connect timeout to 100ms as 60s is far too long.
