### PR TITLE
ESI Only replaces 1 variable within other ESI tags

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -1522,7 +1522,7 @@ function process_esi(self)
 
         -- Replace vars inline in any other esi: tags.
         body = ngx.re.gsub(body,
-            "(<esi:.* )(.+)(.*/>)",
+            "(<esi:)(.+)(.*/>)",
             function(m)
                 local vars = ngx.re.gsub(m[2],
                         "(\\$\\([A-Z_]+[{a-zA-Z\\.-~_%0-9}]*\\))",


### PR DESCRIPTION
For example:
`<esi:include src="/foo/bar?param1=$(HTTP_header1)&param2=$(HTTP_header2)" />`
Only `$(HTTP_header2)` gets replaced.
