### PR TITLE
Bug: ngx.var.args can be nil or an empty string

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -476,7 +476,7 @@ function _M.cache_key(self)
             ngx_var.scheme,
             ngx_var.host,
             ngx_var.uri,
-            ngx_var.args,
+            ngx_var.args or "",
         }
         tbl_insert(key_spec, 1, "cache_obj")
         tbl_insert(key_spec, 1, "ledge")


### PR DESCRIPTION
No query string in the request sets ngx.var.args to nil, but if you use ngx.req.set_uri_args() with an empty table ngx.var.args becomes an empty string.
Not sure if this is intended but means you can get a key mismatch in some situations..
