### PR TITLE
Do not attempt to set ngx.status in abort handler

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -1012,7 +1012,7 @@ _M.events = {
     aborted = {
         { in_case = "response_cacheable", begin = "cancelling_abort_request" },
         { in_case = "obtained_collapsed_forwarding_lock", begin = "cancelling_abort_request" },
-        { begin = "exiting", but_first = "set_http_client_abort" },
+        { begin = "exiting"},
     },
 
     -- The cache body reader was reading from the list, but the entity was collected by a worker
@@ -1235,10 +1235,6 @@ _M.actions = {
 
     set_http_gateway_timeout = function(self)
         ngx.status = ngx.HTTP_GATEWAY_TIMEOUT
-    end,
-
-    set_http_client_abort = function(self)
-        ngx.status = 499 -- No ngx constant for client aborted
     end,
 
     set_http_connection_timed_out = function(self)

--- a/t/18-on_abort.t
+++ b/t/18-on_abort.t
@@ -1,7 +1,7 @@
 use Test::Nginx::Socket;
 use Cwd qw(cwd);
 
-plan tests => repeat_each() * (blocks() * 2) + 1;
+plan tests => repeat_each() * (blocks() * 2) + 2;
 
 my $pwd = cwd();
 
@@ -26,6 +26,11 @@ our $HttpConfig = qq{
     ";
         
     lua_check_client_abort on;
+
+    upstream test-upstream {
+        server 127.0.0.1:1984;
+        keepalive 16;
+    }
 };
 
 no_long_string();
@@ -224,6 +229,51 @@ GET /abort_prx
 --- response_body
 START
 FINISH
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 5: No error when keepalive_requests exceeded
+--- http_config eval: $::HttpConfig
+--- config
+    location = /abort_top {
+        content_by_lua '
+            local http = require "resty.http"
+            local httpc = http.new()
+            local res, err = httpc:request_uri("http://"..ngx.var.server_addr..":"..ngx.var.server_port.."/abort_ngx")
+            if not res then
+                ngx.log(ngx.ERR, err)
+            end
+            local res, err = httpc:request_uri("http://"..ngx.var.server_addr..":"..ngx.var.server_port.."/abort_ngx")
+            if not res then
+                ngx.log(ngx.ERR, err)
+            end
+            ngx.say("OK")
+        ';
+    }
+    location = /abort_ngx {
+        rewrite ^ /abort_prx break;
+        proxy_pass http://test-upstream;
+    }
+    location = /abort_prx {
+        rewrite ^(.*)_prx$ $1 break;
+        keepalive_requests 1;
+        content_by_lua '
+            ledge:run()
+        ';
+    }
+    location = /abort {
+        content_by_lua '
+            ngx.status = 200
+            ngx.header["Cache-Control"] = "public, max-age=3600"
+            ngx.say("START")
+            ngx.say("FINISH")
+       ';
+    }
+--- request
+GET /abort_top
+--- response_body
+OK
 --- error_code: 200
 --- no_error_log
 [error]


### PR DESCRIPTION
This is a bit of a weird one, I can only seem to reproduce it when the nginx upstream/proxy module is talking to Ledge.

When the Ledge server hits the `keepalive_requests` limit the abort handler is triggered and an error is thrown `attempt to set ngx.status after sending out response headers`

```
2015/05/29 11:13:13 [debug] 23794#0: *14 [lua] ledge.lua:1716: e(): #a: redis_close
2015/05/29 11:13:13 [info] 23794#0: *14 client prematurely closed connection, client: 185.64.252.20, server: dev.local, request: "GET /bench.html HTTP/1.1", host: "dev.local"
2015/05/29 11:13:13 [debug] 23794#0: *14 [lua] ledge.lua:1731: e(): #e: aborted
2015/05/29 11:13:13 [debug] 23794#0: *14 [lua] ledge.lua:1758: e(): #a: set_http_client_abort
2015/05/29 11:13:13 [error] 23794#0: *14 attempt to set ngx.status after sending out response headers, client: 185.64.252.20, server: dev.local, request: "GET /bench.html HTTP/1.1", host: "dev.local"
2015/05/29 11:13:13 [debug] 23794#0: *14 [lua] ledge.lua:1716: e(): #a: redis_close
2015/05/29 11:13:13 [warn] 23794#0: *14 [lua] ledge.lua:420: couldn't set keepalive, socket busy reading, client: 185.64.252.20, server: dev.local, request: "GET /bench.html HTTP/1.1", host: "dev.local"
2015/05/29 11:13:13 [debug] 23794#0: *14 [lua] ledge.lua:1716: e(): #a: httpc_close
2015/05/29 11:13:13 [debug] 23794#0: *14 [lua] ledge.lua:1721: e(): #t: exiting
```