### PR TITLE
Allow customisation of uri & params

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -2095,12 +2095,17 @@ function _M.fetch_from_origin(self)
         ngx_log(ngx_ERR, "error getting client body reader: ", err)
     end
 
-    local origin, err = httpc:request{
+    local req_params = {
         method = ngx_req_get_method(),
         path = self:relative_uri(),
         body = client_body_reader,
         headers = headers,
     }
+
+    -- allow request params to be customised
+    self:emit("before_request", req_params)
+
+    local origin, err = httpc:request(req_params)
 
     if not origin then
         ngx_log(ngx_ERR, err)

--- a/t/03-events.t
+++ b/t/03-events.t
@@ -53,3 +53,22 @@ GET /events_1_prx
 --- response_headers
 X-Modified: Modified
 
+=== TEST 2: Customise params prior to request
+--- http_config eval: $::HttpConfig
+--- config
+location /events_2 {
+    content_by_lua '
+        ledge:bind("before_request", function(params)
+            params.path = "/modified"
+        end)
+        ledge:run()
+    ';
+}
+location /modified {
+    echo "ORIGIN";
+}
+--- request
+GET /events_2
+--- response_body
+ORIGIN
+


### PR DESCRIPTION
@pintsized requests with quoted characters are getting munged by ledge. This PR allows us to get the unmunged route and pass it through to the origin.