### PR TITLE
allow disable no-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ coupled with the flexibility to script configuration dynamically.
     * [max_stale](#max_stale)
     * [stale_if_error](#stale_if_error)
     * [cache_key_spec](#cache_key_spec)
+    * [cache_allow_disable](#cache_allow_disable)
     * [enable_collapsed_forwarding](#enable_collapsed_forwarding)
     * [collapsed_forwarding_window](#collapsed_forwarding_window)
     * [esi_enabled](#esi_enabled)
@@ -498,6 +499,16 @@ ledge:cache_obj:http:example.com:/about:p=2&q=foo
 If you're doing SSL termination at Nginx and your origin pages look the same for HTTPS and HTTP
 traffic, you could  provide a cache key spec omitting `ngx.var.scheme`, to avoid splitting the cache
 when the content is identical.
+
+
+### cache_allow_disable
+
+`syntax: ledge:config_set("cache_allow_disable", false)`
+
+`default: true`
+
+Specifies whether a requester can ask for a response to not be cached. When an origin has a high
+resource cost, it may be undesirable for a requester to ask for the cache to not be used.
 
 
 ### enable_collapsed_forwarding

--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -480,12 +480,14 @@ end
 
 function _M.request_accepts_cache(self)
     -- Check for no-cache
-    local h = ngx_req_get_headers()
-    if h_util.header_has_directive(h["Pragma"], "no-cache")
-       or h_util.header_has_directive(h["Cache-Control"], "no-cache")
-       or h_util.header_has_directive(h["Cache-Control"], "no-store") then
-        return false
-    end
+    if not self:config_get("cache_allow_disable") then
+      local h = ngx_req_get_headers()
+      if h_util.header_has_directive(h["Pragma"], "no-cache")
+         or h_util.header_has_directive(h["Cache-Control"], "no-cache")
+         or h_util.header_has_directive(h["Cache-Control"], "no-store") then
+          return false
+      end
+    end 
 
     return true
 end

--- a/t/08-cache.t
+++ b/t/08-cache.t
@@ -535,3 +535,59 @@ GET /qless
 TEST 12
 --- no_error_log
 [error]
+
+
+=== TEST 14: Prime with HEAD into cache (no body); no-cache set in request
+--- http_config eval: $::HttpConfig
+--- config
+    location /cache_14_prx {
+        rewrite ^(.*)_prx$ $1 break;
+        content_by_lua '
+            ledge:config_set("cache_allow_disable", false)
+            ledge:run()
+        ';
+    }
+    location /cache_14 {
+        content_by_lua '
+            ngx.header["Cache-Control"] = "max-age=3600"
+        ';
+    }
+--- more_headers
+Cache-Control: no-cache
+--- request
+HEAD /cache_14_prx
+--- response_headers_like
+X-Cache: MISS from .*
+--- response_body
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+=== TEST 14b: Check HEAD request did not cache
+--- http_config eval: $::HttpConfig
+--- config
+    location /cache_14_prx {
+        rewrite ^(.*)_prx$ $1 break;
+        content_by_lua '
+            ledge:config_set("cache_allow_disable", false)
+            ledge:run()
+        ';
+    }
+    location /cache_14 {
+        content_by_lua '
+            ngx.header["Cache-Control"] = "max-age=3600"
+        ';
+    }
+--- more_headers
+Cache-Control: no-cache
+--- request
+HEAD /cache_14_prx
+--- response_headers_like
+X-Cache: HIT from .*
+--- response_body
+--- error_code: 200
+--- no_error_log
+[error]
+
+


### PR DESCRIPTION
Specify whether a requester should have the ability to forcibly not use the cache when handling the request.

Worth mentioning that we encountered a nasty bug in ledge when using collapsed forwarding and requesters forced a no-cache on their request. We haven't yet found the exact cause, but it seems reasonable to allow disabling the no-cache behaviour via config.