### PR TITLE
Added event for passing headers to the background revalidation

### DIFF
--- a/lib/ledge/jobs/revalidate.lua
+++ b/lib/ledge/jobs/revalidate.lua
@@ -18,13 +18,19 @@ function _M.perform(job)
     local request_line = str_match(job.data.raw_header, "[^\r\n]+")
     local uri = str_match(request_line, "[^%s]+%s([^%s]+)")
 
+    local headers = {
+        ["Host"] = job.data.host,
+        ["Cache-Control"] = "max-stale=0, stale-if-error=0",
+    }
+
+    for k, v in pairs(headers) do
+        job.data.headers[k] = v
+    end
+
     local res, err = httpc:request{
         method = "GET",
         path = uri,
-        headers = {
-            ["Host"] = job.data.host,
-            ["Cache-Control"] = "max-stale=0, stale-if-error=0",
-        },
+        headers = job.data.headers
     }
 
     if not res then

--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -1422,11 +1422,15 @@ _M.actions = {
     end,
 
     revalidate_in_background = function(self)
+        local revalidation_headers = {}
+        self:emit("set_revalidation_headers", revalidation_headers)
+
         self:put_background_job("ledge", "ledge.jobs.revalidate", {
             raw_header = ngx_req_raw_header(),
             host = ngx_var.host,
             server_addr = ngx_var.server_addr,
             server_port = ngx_var.server_port,
+            headers = revalidation_headers
         })
     end,
 


### PR DESCRIPTION
Added functionality to pass desired headers into the background revalidation process.
Overrides passed headers with the Host and Cache-Control in revalidate.lua in order for the process to update correctly.