### PR TITLE
Fix for whitespace in esi include tag

### DIFF
--- a/lib/ledge/esi.lua
+++ b/lib/ledge/esi.lua
@@ -273,7 +273,7 @@ local function esi_fetch_include(include_tag, buffer_size, pre_include_callback,
 
     local src, err = ngx_re_match(
         include_tag,
-        "src=\"(.+)\"[^>*]/>",
+        [[src="([^"]+)"]],
         "oj"
     )
 
@@ -509,7 +509,7 @@ function _M.get_process_filter(reader, pre_include_callback, recursion_limit)
                     repeat
                         local from, to, err = ngx_re_find(
                             chunk,
-                            "<esi:include src=\"[^\"]+\"\\s*/>",
+                            [[<esi:include\s*src="[^"]+"\s*/>]],
                             "oj",
                             ctx
                         )

--- a/t/10-esi.t
+++ b/t/10-esi.t
@@ -1676,3 +1676,33 @@ location /esi_25 {
 GET /esi_25_prx
 --- raw_response_headers_unlike: Surrogate-Control: content="ESI/1.0\"\r\n
 --- response_body: 25a 25b
+
+=== TEST 26: Include tag whitespace
+--- http_config eval: $::HttpConfig
+--- config
+location /esi_26_prx {
+    rewrite ^(.*)_prx$ $1 break;
+    content_by_lua '
+        run()
+    ';
+}
+location /fragment_1 {
+    echo "FRAGMENT";
+}
+location /esi_26 {
+    default_type text/html;
+    content_by_lua '
+        ngx.say("1")
+        ngx.print("<esi:include src=\\"/fragment_1\\"/>")
+        ngx.say("2")
+        ngx.print("<esi:include    	   src=\\"/fragment_1\\"   	  />")
+    ';
+}
+--- request
+GET /esi_26_prx
+--- raw_response_headers_unlike: Surrogate-Control: content="ESI/1.0\"\r\n
+--- response_body
+1
+FRAGMENT
+2
+FRAGMENT


### PR DESCRIPTION
Include tags without a space before closing weren't picked up, we should just ignore whitespace within the tag.
Also switched to square bracket string delimiter to avoid constantly escaping doublequotes.