### PR TITLE
Hash append bug

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -2792,10 +2792,13 @@ function _M.save_to_cache(self, res)
         'esi_scanned', tostring(res.esi_scanned)
     )
 
+    redis:del(key_chain.headers)
     redis:hmset(key_chain.headers, unpack(h))
 
     -- Set revalidation parameters from this request
+    redis:del(key_chain.reval_params)
     redis:hmset(key_chain.reval_params, reval_params)
+    redis:del(key_chain.reval_req_headers)
     redis:hmset(key_chain.reval_req_headers, reval_headers)
 
     -- Mark the keys as eventually volatile (the body is set by the body writer)


### PR DESCRIPTION
As the new data structure only has 1 hash per cache entry for the headers, reval_params etc.
Calling `hmset()` on them with an updated set of headers from the origin overrides existing headers but does not purge old entries from the hash.

e.g.
Cache exists with headers

```
Date: Tue, 18 Oct 2016 11:47:36 GMT
Server: FooBar
X-Test: 123
```

New request comes in and goes to the origin, returns cacheable response with headers

```
Date: Tue, 19 Oct 2016 11:47:36 GMT
Server: BazQux
X-Test2: abc
```

Cache entry now contains

```
Date: Tue, 19 Oct 2016 11:47:36 GMT
Server: BazQux
X-Test: 123
X-Test2: abc
```

I think the correct solution to this is just to `redis:del()` every key before calling `hmset()`.
