### PR TITLE
Use max-age=0 instead of must-revalidate

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -1534,7 +1534,7 @@ _M.actions = {
     zero_downstream_lifetime = function(self)
         local res = self:get_response()
         if res.header then
-            res.header["Cache-Control"] = "private, must-revalidate"
+            res.header["Cache-Control"] = "private, max-age=0"
         end
     end,
 

--- a/t/10-esi.t
+++ b/t/10-esi.t
@@ -636,7 +636,7 @@ location /esi_8 {
 --- request
 GET /esi_8_prx
 --- response_headers_like
-Cache-Control: private, must-revalidate
+Cache-Control: private, max-age=0
 --- raw_response_headers_unlike: Surrogate-Control: content="ESI/1.0\"\r\n
 --- no_error_log
 [error]


### PR DESCRIPTION
Non-Chrome browsers seem to use local cache when Last-Modified or Etag is sent alongside Cache-Control: private, must-revalidate
Setting max-age=0 forces a request with revalidation headers which can be 304'd by Ledge