### PR TITLE
Fix Surrogate-Capability parsing

### DIFF
--- a/lib/ledge/ledge.lua
+++ b/lib/ledge/ledge.lua
@@ -1867,9 +1867,9 @@ _M.states = {
             local surrogate_capability = ngx_req_get_headers()["Surrogate-Capability"]
 
             if surrogate_capability then
-                local capability_parser, capability_version = split_esi_token(
-                    h_util.get_header_token(surrogate_capability, ngx_var.host)
-                )
+                -- Surrogate-Capability: host.example.com="ESI/1.0"
+                local capability_token =  h_util.get_header_token(surrogate_capability, "[!#\\$%&'\\*\\+\\-.\\^_`\\|~0-9a-zA-Z]+")
+                local capability_parser, capability_version = split_esi_token(capability_token)
                 capability_version = tonumber(capability_version)
 
                 if capability_parser and capability_version then


### PR DESCRIPTION
Currently the `Surrogate-Capability` device-token has to match the Host header in the request.
Little bit hacky, this fix uses get_header_token but passes in a regex matching 1 or more <tchar>

We should probably look at a proper header parsing lib of some kind