### PR TITLE
handle case where Via: header is a table

### DIFF
--- a/lib/ledge/handler.lua
+++ b/lib/ledge/handler.lua
@@ -847,11 +847,15 @@ local function serve(self)
         end
         local res_via = res.header["Via"]
         if  (res_via ~= nil) then
-            res.header["Via"] = via .. ", " .. res_via
+            if (type(res_via) == "table") then
+              res.header["Via"] = via .. ", " .. table.concat(res_via, ", ")
+            else
+              res.header["Via"] = via .. ", " .. res_via
+            end
         else
             res.header["Via"] = via
         end
-
+       
         -- X-Cache header
         -- Don't set if this isn't a cacheable response. Set to MISS is we
         -- fetched.


### PR DESCRIPTION
ran into this this morning - one of our data providers just started handing us multiple Via (and other) headers intermittently.

When this happened we would crash out:

```
2017/07/25 16:15:13 [error] 2258#0: *2673826 lua entry thread aborted: runtime error: .../lualib/ledge_cache/ledge/ledge.lua:2929: attempt to concatenate local 'res_via' (a table value)
stack traceback:
coroutine 0:
	.../lualib/ledge_cache/ledge/ledge.lua: in function 'serve'
	../lualib/ledge_cache/ledge/ledge.lua:2214: in function 'e'
	.../lualib/ledge_cache/ledge/ledge.lua:1805: in function 'e'
	.../lualib/ledge_cache/ledge/ledge.lua:450: in function 'run'
	.../lualib/sportradar.lua:94: in function
```

sample response snippet:


```
< Via: 1.1 varnish-v4
< Via: 1.1 varnish-v4
< X-BE-Cache: MISS
< X-FE-Cache: MISS
< X-Varnish: 2219502
< X-Varnish: 1463560
< X-Via: Translation-Proxy
< Content-Length: 50463
< Connection: keep-alive
```