### PR TITLE
Fix setting resty_upstream handler option

### DIFF
--- a/lib/ledge.lua
+++ b/lib/ledge.lua
@@ -65,7 +65,7 @@ local handler_defaults = setmetatable({
     upstream_ssl_verify = true,
 
     use_resty_upstream = false,
-    resty_upstream = nil,
+    resty_upstream = false,
 
     buffer_size = 2^16,
     advertise_ledge = true,

--- a/lib/ledge/handler.lua
+++ b/lib/ledge/handler.lua
@@ -320,8 +320,8 @@ local function read_from_cache(self)
             -- Surely we should just MISS on failure?
             return self:e "http_internal_server_error"
         else
-            ngx.log(ngx.DEBUG, "read mised without error")
-            return {} -- MSS
+            ngx.log(ngx.DEBUG, "read missed without error")
+            return {} -- MISS
         end
     end
 


### PR DESCRIPTION
Can't have default nil's in the current implementation, they become an unknown config option.

Also a minor typo in an error message