### PR TITLE
Resty upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,8 +460,6 @@ inside the `init_by_lua_block` directive, or when creating a handler in a
  * [upstream_use_ssl](#upstream_use_ssl)
  * [upstream_ssl_server_name](#upstream_ssl_server_name)
  * [upstream_ssl_verify](#upstream_ssl_verify)
- * [use_resty_upstream](#use_resty_upstream)
- * [resty_upstream](#resty_upstream)
  * [buffer_size](#buffer_size)
  * [cache_max_memory](#cache_max_memory)
  * [advertise_ledge](#advertise_ledge)
@@ -866,6 +864,7 @@ end)
 ## Event types
 
 * [after_cache_read](#after_cache_read)
+* [before_upstream_connect](#before_upstream_connect)
 * [before_upstream_request](#before_upstream_request)
 * [before_esi_inclulde_request"](#before_esi_include_request)
 * [after_upstream_request](#after_upstream_request)
@@ -880,6 +879,16 @@ syntax: `handler:bind("after_cache_read", function(res) -- end)`
 params: `res` The cached `ledge.response` instance.
 
 Fires directly after the response was successfully loaded from cache.
+
+
+### before_upstream_connect
+
+syntax: `ledge:bind("before_upstream_connect", function(handler) -- end)`
+
+params: `handler`. The current handler instance.
+
+Fires before the default `handler.upstream_client` is created.  
+Use to override the default `resty.http` client and provide a pre-connected client module compatible with `resty.httpc`
 
 
 ### before_upstream_request

--- a/lib/ledge.lua
+++ b/lib/ledge.lua
@@ -64,9 +64,6 @@ local handler_defaults = setmetatable({
     upstream_ssl_server_name = "",
     upstream_ssl_verify = true,
 
-    use_resty_upstream = false,
-    resty_upstream = false,
-
     buffer_size = 2^16,
     advertise_ledge = true,
     keep_cache_for  = 86400 * 30,  -- (sec)
@@ -95,6 +92,7 @@ local handler_defaults = setmetatable({
 -- ledge.bind() and handler:bind() both check validity of event names however.
 local event_defaults = {
     after_cache_read = {},
+    before_upstream_connect = {},
     before_upstream_request = {},
     after_upstream_request = {},
     before_save = {},

--- a/lib/ledge/handler.lua
+++ b/lib/ledge/handler.lua
@@ -77,6 +77,7 @@ local function new(config, events)
     -- public:
         config = config,
         events = events,
+        upstream_client = {},
 
         -- Slots for composed objects
         redis = {},
@@ -374,11 +375,10 @@ local function fetch_from_origin(self)
         return res
     end
 
-    local httpc
-    if self.config.use_resty_upstream then
-        httpc = self.config.resty_upstream
-    else
-        httpc = http.new()
+    emit(self, "before_upstream_connect", self)
+
+    if not next(self.upstream_client) then
+        local httpc = http.new()
         httpc:set_timeout(self.config.upstream_connect_timeout)
 
         local ok, err = httpc:connect(
@@ -387,6 +387,7 @@ local function fetch_from_origin(self)
         )
 
         if not ok then
+            ngx_log(ngx_ERR, "upstream connection failed: ", err)
             if err == "timeout" then
                 res.status = 524 -- upstream server timeout
             else
@@ -410,9 +411,10 @@ local function fetch_from_origin(self)
                 return res
             end
         end
+        self.upstream_client = httpc
     end
 
-    res.conn = httpc
+    local upstream_client = self.upstream_client
 
     -- Case insensitve headers so that we can safely manipulate them
     local headers = http_headers.new()
@@ -436,7 +438,7 @@ local function fetch_from_origin(self)
     end
 
     local client_body_reader, err =
-        httpc:get_client_body_reader(self.config.buffer_size)
+        upstream_client:get_client_body_reader(self.config.buffer_size)
 
     if err then
         ngx_log(ngx_ERR, "error getting client body reader: ", err)
@@ -452,7 +454,7 @@ local function fetch_from_origin(self)
     -- allow request params to be customised
     emit(self, "before_upstream_request", req_params)
 
-    local origin, err = httpc:request(req_params)
+    local origin, err = upstream_client:request(req_params)
 
     if not origin then
         ngx_log(ngx_ERR, err)

--- a/lib/ledge/response.lua
+++ b/lib/ledge/response.lua
@@ -55,9 +55,6 @@ function _M.new(redis, key_chain)
         redis = redis,
         key_chain = key_chain,  -- Cache key chain
 
-        conn = {},  -- httpc instance, TODO is this used? Yes, set by handler
-                    -- and pulled out in http_close action. Weird.
-
         uri = "",
         status = 0,
         header = http_headers.new(),

--- a/lib/ledge/state_machine/actions.lua
+++ b/lib/ledge/state_machine/actions.lua
@@ -28,11 +28,10 @@ return {
     end,
 
     httpc_close = function(handler)
-        local res = handler.response
-        if next(res) then
-            local httpc = res.conn
-            if httpc and type(httpc.set_keepalive) == "function" then
-                return httpc:set_keepalive()
+        local upstream_client = handler.upstream_client
+        if next(upstream_client) then
+            if type(upstream_client.set_keepalive) == "function" then
+                return upstream_client:set_keepalive() -- TODO: Get keepalive settings from handler config
             end
         end
     end,

--- a/t/02-integration/upstream_client.t
+++ b/t/02-integration/upstream_client.t
@@ -1,0 +1,173 @@
+use Test::Nginx::Socket 'no_plan';
+use Cwd qw(cwd);
+
+my $pwd = cwd();
+
+$ENV{TEST_NGINX_PORT} |= 1984;
+$ENV{TEST_LEDGE_REDIS_DATABASE} |= 2;
+$ENV{TEST_LEDGE_REDIS_QLESS_DATABASE} |= 3;
+$ENV{TEST_COVERAGE} ||= 0;
+
+our $HttpConfig = qq{
+lua_package_path "./lib/?.lua;../lua-resty-redis-connector/lib/?.lua;../lua-resty-qless/lib/?.lua;../lua-resty-http/lib/?.lua;../lua-ffi-zlib/lib/?.lua;;";
+lua_shared_dict test_upstream_dict 1m;
+
+init_by_lua_block {
+    if $ENV{TEST_COVERAGE} == 1 then
+        require("luacov.runner").init()
+    end
+
+    require("ledge").configure({
+        redis_connector_params = {
+            db = $ENV{TEST_LEDGE_REDIS_DATABASE},
+        },
+        qless_db = $ENV{TEST_LEDGE_REDIS_QLESS_DATABASE},
+    })
+
+
+    function create_upstream_client(config)
+        -- Defaults
+        config = config or {}
+        config["timeout"]      = config["timeout"] or 100
+        config["read_timeout"] = config["read_timeout"] or 500
+        config["host"]         = config["host"] or "127.0.0.1"
+        config["port"]         = config["port"] or $ENV{TEST_NGINX_PORT}
+
+        return function(handler)
+            local httpc = require("resty.http").new()
+            httpc:set_timeout(config.timeout)
+
+            local ok, err = httpc:connect(
+                config.host,
+                config.port
+            )
+
+            if not ok then
+                ngx.log(ngx.ERR, "upstream client connection failed: ", err)
+                return nil
+            end
+
+            httpc:set_timeout(config.read_timeout)
+
+            handler.upstream_client = httpc
+        end
+    end
+
+
+    require("ledge").set_handler_defaults({
+        storage_driver_config = {
+            redis_connector_params = {
+                db = $ENV{TEST_LEDGE_REDIS_DATABASE},
+            },
+        }
+    })
+    require("ledge").bind("before_upstream_connect", function(handler)
+        if ngx.req.get_uri_args()["skip_init"] then
+            -- do nothing
+        else
+            -- create handler and pass through res
+            create_upstream_client()(handler)
+        end
+    end)
+}
+
+init_worker_by_lua_block {
+    require("ledge").create_worker():run()
+}
+
+};
+
+no_long_string();
+no_diff();
+run_tests();
+
+
+__DATA__
+=== TEST 1: Sanity, response returned with upstream_client configured
+--- http_config eval: $::HttpConfig
+--- config
+location /upstream_client_prx {
+    rewrite ^(.*)_prx$ $1 break;
+    content_by_lua_block {
+        require("ledge").create_handler():run()
+    }
+}
+location /upstream_client {
+    content_by_lua_block {
+        ngx.say("OK")
+    }
+}
+--- request
+GET /upstream_client_prx
+--- no_error_log
+[error]
+--- error_code: 200
+--- response_body
+OK
+
+=== TEST 1b: Sanity, response returned with upstream_client configured at runtime
+--- http_config eval: $::HttpConfig
+--- config
+location /upstream_client_prx {
+    rewrite ^(.*)_prx$ $1 break;
+    content_by_lua_block {
+        local h = require("ledge").create_handler()
+        h:bind("before_upstream_connect", create_upstream_client() )
+        h:run()
+    }
+}
+location /upstream_client {
+    content_by_lua_block {
+        ngx.say("OK")
+    }
+}
+--- request
+GET /upstream_client_prx?skip_init=true
+--- no_error_log
+[error]
+--- error_code: 200
+--- response_body
+OK
+
+=== TEST 2: Short read timeout results in error 524.
+--- http_config eval: $::HttpConfig
+--- config
+location /upstream_client_prx {
+    rewrite ^(.*)_prx$ $1 break;
+    content_by_lua_block {
+        require("ledge").create_handler():run()
+    }
+}
+location /upstream_client {
+    content_by_lua_block {
+        ngx.sleep(1)
+        ngx.say("OK")
+    }
+}
+--- request
+GET /upstream_client_prx
+--- error_code: 524
+--- response_body
+--- error_log
+timeout
+
+
+=== TEST 2: No upstream results in a 503.
+--- http_config eval: $::HttpConfig
+--- config
+location /upstream_client_prx {
+    rewrite ^(.*)_prx$ $1 break;
+    content_by_lua_block {
+        local h = require("ledge").create_handler()
+        h:bind("before_upstream_connect", function(handler) 
+            handler.upstream_client = {}
+        end)
+        h:run()
+    }
+}
+--- request
+GET /upstream_client_prx
+--- error_code: 503
+--- response_body
+--- error_log
+upstream connection failed


### PR DESCRIPTION

Adds new feature handler.upstream_client

Removes `use_resty_upstream` flag and `resty_upstream` config options 
Adds `before_upstream_connect` event, use this to set handler.upstream_client to module compatible with resty.http
Always log connection errors in default upstream client


