### PR TITLE
Use plain string functions in str_split

### DIFF
--- a/lib/ledge/jobs/revalidate.lua
+++ b/lib/ledge/jobs/revalidate.lua
@@ -2,8 +2,6 @@ local http = require "resty.http"
 local http_headers = require "resty.http_headers"
 local ngx_null = ngx.null
 
-local str_match = string.match
-
 local _M = {
     _VERSION = '1.28.6',
 }

--- a/lib/ledge/util.lua
+++ b/lib/ledge/util.lua
@@ -4,7 +4,8 @@ local ffi = require "ffi"
 local type, next, setmetatable, getmetatable, error, tostring, select =
         type, next, setmetatable, getmetatable, error, tostring, select
 
-local str_gmatch = string.gmatch
+local str_find = string.find
+local str_sub = string.sub
 local tbl_insert = table.insert
 local co_create = coroutine.create
 local co_status = coroutine.status
@@ -55,19 +56,23 @@ _M.string.randomhex = randomhex
 
 
 local function str_split(str, delim)
-    if not str or not delim then return nil end
-    local it, err = str_gmatch(str, "([^"..delim.."]+)")
-    if it then
-        local output = {}
-        while true do
-            local m, err = it()
-            if not m then
-                break
+    local pos, endpos, prev, i = 0, 0, 0, 0
+    local out = {}
+    repeat
+        pos, endpos = str_find(str, delim, prev, true)
+        i = i+1
+        if pos then
+            out[i] = str_sub(str, prev, pos-1)
+        else
+            if prev <= #str then
+                out[i] = str_sub(str, prev, -1)
             end
-            tbl_insert(output, m)
+            break
         end
-        return output
-    end
+        prev = endpos +1
+    until pos == nil
+
+    return out
 end
 _M.string.split = str_split
 

--- a/t/01-unit/util.t
+++ b/t/01-unit/util.t
@@ -335,7 +335,7 @@ location /t {
         assert(t[4] == " ", "t[4] should be ' '")
 
         local t = str_split(str1, ", ")
-        assert(#t == 3, "#t should be 4")
+        assert(#t == 3, "#t should be 3")
         assert(t[1] == "comma", "t[1] should be 'comma'")
         assert(t[2] == "separated", "t[2] should be ' separated'")
         assert(t[3] == "string", "t[3] should be ' string'")


### PR DESCRIPTION
Using string.find and string.sub is about twice as fast as string.gmatch and are JiTable