### PR TITLE
Fixes for metadata transaction abort

### DIFF
--- a/lib/ledge.lua
+++ b/lib/ledge.lua
@@ -155,6 +155,7 @@ local function create_redis_connection()
     if not rc then
         return nil, err
     end
+
     return rc:connect()
 end
 _M.create_redis_connection = create_redis_connection
@@ -170,6 +171,7 @@ local function create_redis_slave_connection()
     if not rc then
         return nil, err
     end
+
     return rc:connect()
 end
 _M.create_redis_slave_connection = create_redis_slave_connection
@@ -181,12 +183,13 @@ local function close_redis_connection(redis)
         -- Ensure we actually have a resty-redis instance to close
         return nil
     end
+
     local rc, err = redis_connector.new(config.redis_connector_params)
     if not rc then
         return nil, err
     end
-    return rc:set_keepalive(redis)
 
+    return rc:set_keepalive(redis)
 end
 _M.close_redis_connection = close_redis_connection
 

--- a/lib/ledge.lua
+++ b/lib/ledge.lua
@@ -176,6 +176,11 @@ _M.create_redis_slave_connection = create_redis_slave_connection
 
 
 local function close_redis_connection(redis)
+    if not next(redis) then
+        -- Possible for this to be called before we've created a redis conn
+        -- Ensure we actually have a resty-redis instance to close
+        return nil
+    end
     local rc, err = redis_connector.new(config.redis_connector_params)
     if not rc then
         return nil, err

--- a/lib/ledge/handler.lua
+++ b/lib/ledge/handler.lua
@@ -736,8 +736,8 @@ local function save_to_cache(self, res)
                     -- Transaction likely failed due to watch on main key
                     -- Tell storage to clean up too
                     ok, e = storage:delete(res.entity_id)
-                    if not ok or ok == ngx_null then
-                        ngx_log(ngx.ERR, "failed to cleanup storage: ", e)
+                    if e then
+                        ngx_log(ngx_ERR, "failed to cleanup storage: ", e)
                     end
                 end
             elseif previous_entity_id then

--- a/lib/ledge/handler.lua
+++ b/lib/ledge/handler.lua
@@ -686,6 +686,7 @@ local function save_to_cache(self, res)
                 ngx_log(ngx_ERR, err)
             end
         end
+
         -- Define GC job here, used later if required
         gc_job_spec = {
             "ledge_gc",


### PR DESCRIPTION
Don't schedule garbage collection of the old entity until we have confirmed the new cache entry has been confirmed on both storage and metadata.
Background jobs are submitted on a new connection and so won't be rolled back by the transaction failure.

Additionally make sure we tell storage to delete the just-written entity if the metadata connection fails to commit its transaction.

And only log `exec()` failures if there is an error, rather than just a `nil` response, indicating the watched key was changed.

@pintsized I know you're busy but could you just sanity check this one?