### PR TITLE
ESI conditions

### DIFF
--- a/lib/ledge/esi/processor_1_0.lua
+++ b/lib/ledge/esi/processor_1_0.lua
@@ -259,7 +259,7 @@ local function _esi_condition_lexer(condition)
                     )
                     if not re then
                         ngx_log(ngx_INFO,
-                            "Parse error: could not parse regular expression",
+                            "Parse error: could not parse regular expression ",
                             "in: \"", condition, "\""
                         )
                         return nil

--- a/lib/ledge/esi/processor_1_0.lua
+++ b/lib/ledge/esi/processor_1_0.lua
@@ -345,6 +345,7 @@ local function _esi_evaluate_condition(condition)
         return false
     end
 end
+_M._esi_evaluate_condition = _esi_evaluate_condition
 
 
 -- Replaces all variables in <esi:vars> blocks, or inline within other esi:tags.

--- a/t/01-unit/processor_1_0.t
+++ b/t/01-unit/processor_1_0.t
@@ -508,3 +508,105 @@ GET /t?test_param=test
 --- response_body
 OK
 
+=== TEST 10: _esi_condition_lexer
+--- http_config eval: $::HttpConfig
+--- config
+location /t {
+    content_by_lua_block {
+        local processor = require("ledge.esi.processor_1_0")
+        local tests = {
+        -- Basic operators
+            {
+                ["condition"] = [[1 == 1]],
+                ["res"]   = [[1 == 1]],
+                ["msg"]   = "equality"
+            },
+            {
+                ["condition"] = [[1 != 1]],
+                ["res"]   = [[1 ~= 1]],
+                ["msg"]   = "negative equality"
+            },
+            {
+                ["condition"] = [[1 | 2]],
+                ["res"]   = [[1  or  2]],
+                ["msg"]   = "or"
+            },
+            {
+                ["condition"] = [[1 || 2]],
+                ["res"]   = [[1  or  2]],
+                ["msg"]   = "double or"
+            },
+            {
+                ["condition"] = [[1 & 2]],
+                ["res"]   = [[1  and  2]],
+                ["msg"]   = "and"
+            },
+            {
+                ["condition"] = [[1 && 2]],
+                ["res"]   = [[1  and  2]],
+                ["msg"]   = "double and"
+            },
+            {
+                ["condition"] = [[!1]],
+                ["res"]   = [[ not  1]],
+                ["msg"]   = "boolean not"
+            },
+        -- regex operator
+            {
+                ["condition"] = [['foo' =~ '/(foo|bar)/']],
+                ["res"]   = [[find('foo', '(foo|bar)', 'oj')]],
+                ["msg"]   = "regex"
+            },
+        }
+        for _, t in pairs(tests) do
+            local ok, output = processor._esi_condition_lexer(t["condition"])
+            ngx.log(ngx.DEBUG, "'", output, "'")
+            assert(ok == true and output == t["res"], "_esi_condition_lexer mismatch: "..t["msg"] )
+        end
+
+        -- Failure cases
+        local tests = {
+            {
+                ["condition"] = [[1 'foo']],
+                ["msg"]   = "string after number"
+            },
+            {
+                ["condition"] = [['foo' 1]],
+                ["msg"]   = "string before number"
+            },
+            {
+                ["condition"] = [[== =~ '/(foo|bar)/']],
+                ["msg"]   = "regex against operatpr"
+            },
+            {
+                ["condition"] = [['/(foo|bar)/' =~ 'foo']],
+                ["msg"]   = "inverse regex"
+            },
+            {
+                ["condition"] = [['/foo|bar)/' =~ 'foo']],
+                ["msg"]   = "invalid regex"
+            },
+
+        }
+        for _, t in pairs(tests) do
+            local ok, output = processor._esi_condition_lexer(t["condition"])
+            ngx.log(ngx.DEBUG, "'", output, "'")
+            assert( not ok, "_esi_condition_lexer should fail: "..t["msg"] )
+        end
+        ngx.say("OK")
+    }
+}
+
+--- request
+GET /t
+--- no_error_log
+[error]
+--- error_log eval
+[
+"Parse error: found string after number",
+"Parse error: found number after string",
+"Parse error: regular expression attempting against non-string",
+"Parse error: could not parse regular expression in: \"'/foo|bar)/'",
+]
+--- response_body
+OK

--- a/t/01-unit/processor_1_0.t
+++ b/t/01-unit/processor_1_0.t
@@ -610,3 +610,136 @@ GET /t
 ]
 --- response_body
 OK
+
+=== TEST 11: _esi_evaluate_condition
+--- http_config eval: $::HttpConfig
+--- config
+location /t {
+    content_by_lua_block {
+        local processor = require("ledge.esi.processor_1_0")
+        local tests = {
+        -- Basic operators
+            {
+                ["condition"] = [[1 == 1]],
+                ["res"]       = true,
+                ["msg"]       = "equality"
+            },
+            {
+                ["condition"] = [[1 == 2]],
+                ["res"]       = false,
+                ["msg"]       = "equality - negative"
+            },
+            {
+                ["condition"] = [['foo' == 'foo']],
+                ["res"]       = true,
+                ["msg"]       = "equality string"
+            },
+            {
+                ["condition"] = [['foo' == 'bar']],
+                ["res"]       = false,
+                ["msg"]       = "equality string - negative"
+            },
+
+            {
+                ["condition"] = [[1 != 1]],
+                ["res"]       = false,
+                ["msg"]       = "inverse equality"
+            },
+            {
+                ["condition"] = [[1 != 2]],
+                ["res"]       = true,
+                ["msg"]       = "inverse equality - negative"
+            },
+            {
+                ["condition"] = [['foo' != 'foo']],
+                ["res"]       = false,
+                ["msg"]       = "inverse equality string"
+            },
+            {
+                ["condition"] = [['foo' != 'bar']],
+                ["res"]       = true,
+                ["msg"]       = "inverse equality string - negative"
+            },
+
+            {
+                ["condition"] = [[1 | 2]],
+                --["res"]       = true,
+                ["res"]       = 1,
+                ["msg"]       = "or"
+            },
+            {
+                ["condition"] = [['foo' | 'bar']],
+                --["res"]       = true,
+                ["res"]       = 'foo',
+                ["msg"]       = "string or"
+            },
+           --[===[
+            {
+                ["condition"] = [[false | false]],
+                ["res"]       = false,
+                ["msg"]       = "or - negative"
+            },
+            --]===]
+
+
+            {
+                ["condition"] = [[1 && 2]],
+                --["res"]       = true,
+                ["res"]       = 2,
+                ["msg"]       = "and"
+            },
+            {
+                ["condition"] = [['foo' && 'bar']],
+                --["res"]       = true,
+                ["res"]       = 'bar',
+                ["msg"]       = "and string"
+            },
+           --[===[ {
+                ["condition"] = [[1 && false]],
+                ["res"]       = false,
+                ["msg"]       = "and - negative"
+            },
+            --]===]
+
+           --[===[ {
+                ["condition"] = [[!true]],
+                --["res"]       = true,
+                ["res"]       = nil,
+                ["msg"]       = "boolean not"
+            },
+
+            {
+                ["condition"] = [[ ! false]],
+                ["res"]       = false,
+                ["msg"]       = "boolean not - negative"
+            },
+            --]===]
+        -- regex operator
+            {
+                ["condition"] = [['foo' =~ '/(foo|bar)/']],
+                --["res"]       = true,
+                ["res"]       = 1,
+                ["msg"]       = "regex"
+            },
+            {
+                ["condition"] = [['foo' =~ '/(qux|baz)/']],
+                --["res"]       = false,
+                ["res"]       = nil,
+                ["msg"]       = "regex"
+            },
+        }
+        for _, t in pairs(tests) do
+            local ok = processor._esi_evaluate_condition(t["condition"])
+            ngx.log(ngx.DEBUG, "'", t["condition"], "' = ", ok)
+            assert(ok == t["res"], "_esi_evaluate_condition mismatch: "..t["msg"] )
+        end
+        ngx.say("OK")
+    }
+}
+
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+OK


### PR DESCRIPTION
Creating a PR for this because I think some of these behaviours are wrong.

The ESI spec says...

>Logical operators ("&", "|", "!") can be used to qualify expressions, but cannot be used as comparitors themselves.
>For example, the following expressions are correct:

```
!(1==1)
!('a'<='c')
(1==1)|('abc'=='def')
(4!=5)&(4==5)
```
>while these will not evaluate:

```
(1 & 4)
("abc" | "edf")
```

The condition_lexer will allow those second type of conditions and parse them to Lua.

evaluate_condition also returns non-boolean values for some conditions which seems wrong?

Also some conditions that pass through the lexer result in errors in the evaluator because they are invalid Lua. We should probably try and catch these too.