### PR TITLE
Refactor cache key generation

### DIFF
--- a/lib/ledge/cache_key.lua
+++ b/lib/ledge/cache_key.lua
@@ -1,0 +1,105 @@
+local ipairs, next, type, pcall, setmetatable =
+      ipairs, next, type, pcall, setmetatable
+
+local ngx_log = ngx.log
+local ngx_ERR = ngx.ERR
+local ngx_var = ngx.var
+
+local tbl_insert = table.insert
+local tbl_concat = table.concat
+
+local req_args_sorted = require("ledge.request").args_sorted
+local req_default_args = require("ledge.request").default_args
+
+local get_fixed_field_metatable_proxy =
+    require("ledge.util").mt.get_fixed_field_metatable_proxy
+
+
+local _M = {
+    _VERSION = "2.0.0",
+}
+
+
+-- Generates the cache key. The default spec is:
+-- ledge:cache_obj:http:example.com:/about:p=3&q=searchterms
+local function generate_cache_key(key_spec, max_args)
+    -- If key_spec is empty, provide a default
+    if not next(key_spec) then
+        key_spec = {
+            "scheme",
+            "host",
+            "uri",
+            "args",
+        }
+    end
+
+    local key = {
+        "ledge",
+        "cache",
+    }
+
+    for _, field in ipairs(key_spec) do
+        if field == "scheme" then
+            tbl_insert(key, ngx_var.scheme)
+        elseif field == "host" then
+            tbl_insert(key, ngx_var.host)
+        elseif field == "port" then
+            tbl_insert(key, ngx_var.server_port)
+        elseif field == "uri" then
+            tbl_insert(key, ngx_var.uri)
+        elseif field == "args" then
+            tbl_insert(
+                key,
+                req_args_sorted(max_args) or req_default_args()
+            )
+
+        elseif type(field) == "function" then
+            local ok, res = pcall(field)
+            if not ok then
+                ngx_log(ngx_ERR,
+                    "error in function supplied to cache_key_spec: ", res
+                )
+            elseif type(res) ~= "string" then
+                ngx_log(ngx_ERR,
+                    "functions supplied to cache_key_spec must " ..
+                    "return a string"
+                )
+            else
+                tbl_insert(key, res)
+            end
+        end
+    end
+
+    return tbl_concat(key, ":")
+end
+_M.generate_cache_key = generate_cache_key
+
+
+-- Returns the key chain for all cache keys, except the body entity
+local function key_chain(cache_key)
+    return setmetatable({
+        -- hash: cache key metadata
+        main = cache_key .. "::main",
+
+        -- sorted set: current entities score with sizes
+        entities = cache_key .. "::entities",
+
+        -- hash: response headers
+        headers = cache_key .. "::headers",
+
+        -- hash: request headers for revalidation
+        reval_params = cache_key .. "::reval_params",
+
+        -- hash: request params for revalidation
+        reval_req_headers = cache_key .. "::reval_req_headers",
+
+    }, get_fixed_field_metatable_proxy({
+        -- Hide "root" and "fetching_lock" from iterators.
+        root = cache_key,
+        fetching_lock = cache_key .. "::fetching",
+    }))
+end
+_M.key_chain = key_chain
+
+
+return _M

--- a/lib/ledge/handler.lua
+++ b/lib/ledge/handler.lua
@@ -31,10 +31,11 @@ local esi_capabilities = require("ledge.esi").esi_capabilities
 
 local append_server_port = require("ledge.util").append_server_port
 
+local generate_cache_key = require("ledge.cache_key").generate_cache_key
+local key_chain = require("ledge.cache_key").key_chain
+
 local req_relative_uri = require("ledge.request").relative_uri
 local req_full_uri = require("ledge.request").full_uri
-local req_args_sorted = require("ledge.request").args_sorted
-local req_default_args = require("ledge.request").default_args
 
 local put_background_job = require("ledge.background").put_background_job
 local gc_wait = require("ledge.background").gc_wait
@@ -183,96 +184,21 @@ end
 _M.emit = emit
 
 
--- Generates or returns the cache key. The default spec is:
--- ledge:cache_obj:http:example.com:/about:p=3&q=searchterms
 local function cache_key(self)
-    if self._cache_key ~= "" then return self._cache_key end
-
-    local key_spec = self.config.cache_key_spec
-
-    -- If key_spec is empty, provide a default
-    if not next(key_spec) then
-        key_spec = {
-            "scheme",
-            "host",
-            "uri",
-            "args",
-        }
-    end
-
-    local key = {
-        "ledge",
-        "cache",
-    }
-
-    for _, field in ipairs(key_spec) do
-        if field == "scheme" then
-            tbl_insert(key, ngx_var.scheme)
-        elseif field == "host" then
-            tbl_insert(key, ngx_var.host)
-        elseif field == "port" then
-            tbl_insert(key, ngx_var.server_port)
-        elseif field == "uri" then
-            tbl_insert(key, ngx_var.uri)
-        elseif field == "args" then
-            tbl_insert(
-                key,
-                req_args_sorted(self.config.max_uri_args) or req_default_args()
+    if self._cache_key == "" then
+        self._cache_key = generate_cache_key(
+                self.config.cache_key_spec,
+                self.config.max_uri_args
             )
-
-        elseif type(field) == "function" then
-            local ok, res = pcall(field)
-            if not ok then
-                ngx_log(ngx_ERR,
-                    "error in function supplied to cache_key_spec: ", res
-                )
-            elseif type(res) ~= "string" then
-                ngx_log(ngx_ERR,
-                    "functions supplied to cache_key_spec must " ..
-                    "return a string"
-                )
-            else
-                tbl_insert(key, res)
-            end
-        end
     end
-
-    self._cache_key = tbl_concat(key, ":")
     return self._cache_key
 end
 _M.cache_key = cache_key
 
 
--- Returns the key chain for all cache keys, except the body entity
-local function key_chain(cache_key)
-    return setmetatable({
-        -- hash: cache key metadata
-        main = cache_key .. "::main",
-
-        -- sorted set: current entities score with sizes
-        entities = cache_key .. "::entities",
-
-        -- hash: response headers
-        headers = cache_key .. "::headers",
-
-        -- hash: request headers for revalidation
-        reval_params = cache_key .. "::reval_params",
-
-        -- hash: request params for revalidation
-        reval_req_headers = cache_key .. "::reval_req_headers",
-
-    }, get_fixed_field_metatable_proxy({
-        -- Hide "root" and "fetching_lock" from iterators.
-        root = cache_key,
-        fetching_lock = cache_key .. "::fetching",
-    }))
-end
-
-
 local function cache_key_chain(self)
     if not next(self._cache_key_chain) then
-        local cache_key = cache_key(self)
-        self._cache_key_chain = key_chain(cache_key)
+        self._cache_key_chain = key_chain(cache_key(self))
     end
     return self._cache_key_chain
 end


### PR DESCRIPTION
This branch moves the functions which actually generate a cache key into a separate module.
They can now be called directly to generate a fresh cache key without having to manually reset the handler instance cache.

Also allows passing a table of values into the generate function so that we can generate cache keys headlessly without having to manipulate the current request variables.

Which will be useful for testing and for a coming bulk PURGE API. 

Supporting this with custom cache key functions is a little weird.
Currently I'm just passing through the vars table to each function.
Those functions will have to check both the custom vars first and then ngx.* output. (See example test)

I'm wondering if it would be worth just always passing a vars table with some sensible values into cache key functions? e.g. headers, uri/request_uri, args, scheme
Then custom cache key functions can just use these always.

Any thoughts?