### PR TITLE
Purge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,38 @@ limit_except GET POST PUT DELETE {
 
 [Back to TOC](#table-of-contents)
 
+
+### JSON API
+
+A JSON based API is also available for purging cache multiple cache items at once.  
+This requires a `PURGE` request with a `Content-Type` header set to `application/json` and a valid JSON request body.
+
+Valid parameters
+ * `uris` - Array of URIs to purge, can contain wildcard URIs
+ * `purge_mode` - As the `X-Purge` header in a normal purge request
+ * `headers` - Hash of additional headers to include in the purge request
+
+Returns a results hash keyed by URI or a JSON error response
+
+`$> curl -X PURGE -H "Content-Type: Application/JSON" http://cache.example.com/ -d '{"uris": ["http://www.example.com/1", "http://www.example.com/2"]}' | jq .`
+
+```json
+{
+  "purge_mode": "invalidate",
+  "result": {
+    "http://www.example.com/1": {
+      "result": "purged"
+    },
+    "http://www.example.com/2":{
+      "result": "nothing to purge"
+    }
+  }
+}
+```
+
+[Back to TOC](#table-of-contents)
+
+
 ### Wildcard purging
 
 Wildcard (\*) patterns are also supported in `PURGE` URIs, which will always return a status of `200` and a JSON body detailing a background job. Wildcard purges involve scanning the entire keyspace, and so can take a little while. See [keyspace\_scan\_count](#keyspace_scan_count) for tuning help.

--- a/lib/ledge/handler.lua
+++ b/lib/ledge/handler.lua
@@ -476,9 +476,8 @@ local function revalidation_data(self)
 end
 
 
-local function revalidate_in_background(self, update_revalidation_data)
+local function revalidate_in_background(self, key_chain, update_revalidation_data)
     local redis = self.redis
-    local key_chain = cache_key_chain(self)
 
     -- Revalidation data is updated if this is a proper request, but not if
     -- it's a purge request.
@@ -736,12 +735,13 @@ end
 _M.save_to_cache = save_to_cache
 
 
-local function delete_from_cache(self)
+local function delete_from_cache(self, key_chain, entity_id)
     local redis = self.redis
-    local key_chain = cache_key_chain(self)
+
+    -- Get entity_id if not already provided
+    entity_id = entity_id or self:entity_id(key_chain)
 
     -- Schedule entity collection
-    local entity_id = self:entity_id(key_chain)
     if entity_id then
         local config = self.config
         local size = redis:hget(key_chain.main, "size")

--- a/lib/ledge/purge.lua
+++ b/lib/ledge/purge.lua
@@ -234,7 +234,7 @@ local function validate_api_request(req)
 end
 
 
-local function key_chain_from_uri(handler, uri)
+local function key_chain_from_uri(handler, uri, headers)
     local parsed, err = http:parse_uri(uri, false)
     if not parsed then
         return nil, "URI Parse Error: "..err
@@ -264,6 +264,7 @@ local function key_chain_from_uri(handler, uri)
         ["port"] = parsed[3],
         ["uri"] = uri,
         ["args"] = args,
+        ["headers"] = headers,
     }
 
     -- Generate new cache_key
@@ -303,7 +304,7 @@ local function purge_api(handler)
     local uris = request["uris"]
     for _, uri in ipairs(uris) do
         local res = {}
-        local key_chain, err = key_chain_from_uri(handler, uri)
+        local key_chain, err = key_chain_from_uri(handler, uri, request["headers"])
 
         if not key_chain then
             res["error"] = err

--- a/lib/ledge/purge.lua
+++ b/lib/ledge/purge.lua
@@ -153,8 +153,9 @@ end
 _M.purge = purge
 
 
-local function schedule_purge_job(handler, purge_mode, key_chain)
-    return put_background_job(
+local function purge_in_background(handler, purge_mode)
+    local key_chain = handler:cache_key_chain()
+    local job, err = put_background_job(
         "ledge_purge",
         "ledge.jobs.purge",
         {
@@ -170,11 +171,6 @@ local function schedule_purge_job(handler, purge_mode, key_chain)
             priority = 5,
         }
     )
-end
-
-
-local function purge_in_background(handler, purge_mode)
-    local job, err = schedule_purge_job(handler, purge_mode, handler:cache_key_chain())
     if err then ngx_log(ngx_ERR, err) end
 
     -- Create a JSON payload for the response

--- a/lib/ledge/request.lua
+++ b/lib/ledge/request.lua
@@ -4,7 +4,8 @@ local ngx_req_get_headers = ngx.req.get_headers
 local ngx_re_gsub = ngx.re.gsub
 local ngx_req_get_uri_args = ngx.req.get_uri_args
 local ngx_req_get_method = ngx.req.get_method
-local ngx_re_find = ngx.re.find
+
+local str_byte = string.byte
 
 local ngx_var = ngx.var
 
@@ -103,10 +104,10 @@ _M.args_sorted = args_sorted
 -- If you override the "args" field in a cache key spec with your own function,
 -- you'll want to use this to ensure wildcard purges operate correctly.
 local function default_args()
-    if ngx_req_get_method() == "PURGE" then
-        if ngx_re_find(ngx_var.request_uri, "\\*$", "soj") then
-            return "*"
-        end
+    if ngx_req_get_method() == "PURGE" and
+       str_byte(ngx_var.request_uri, -1) == 42
+    then
+        return "*"
     end
     return ""
 end

--- a/lib/ledge/state_machine/actions.lua
+++ b/lib/ledge/state_machine/actions.lua
@@ -180,7 +180,7 @@ return {
     -- Updates the realidation_params key with data from the current request,
     -- and schedules a background revalidation job
     revalidate_in_background = function(handler)
-        return handler:revalidate_in_background(true)
+        return handler:revalidate_in_background(handler:cache_key_chain(), true)
     end,
 
     -- Triggered on upstream partial content, assumes no stored
@@ -196,7 +196,7 @@ return {
     end,
 
     delete_from_cache = function(handler)
-        return handler:delete_from_cache()
+        return handler:delete_from_cache(handler:cache_key_chain())
     end,
 
     disable_output_buffers = function(handler)

--- a/lib/ledge/state_machine/events.lua
+++ b/lib/ledge/state_machine/events.lua
@@ -28,7 +28,18 @@ return {
             begin = "purging",
             but_first = "set_json_response"
         },
-        { begin = "considering_wildcard_purge" },
+        {
+            when = "considering_purge_api",
+            begin = "considering_wildcard_purge"
+        },
+        { begin = "considering_purge_api" },
+    },
+
+    purge_api_requested = {
+        {
+            begin = "purging_via_api",
+            but_first = "set_json_response"
+        },
     },
 
     wildcard_purge_requested = {
@@ -42,6 +53,14 @@ return {
 
     wildcard_purge_scheduled = {
         { begin = "serving", but_first = "set_http_ok" },
+    },
+
+    purge_api_completed = {
+        { begin = "serving", but_first = "set_http_ok" },
+    },
+
+    purge_api_failed = {
+        { begin = "serving", but_first = "set_http_status_from_response" },
     },
 
     -- URI to purge was not found. Exit 404 Not Found.

--- a/lib/ledge/state_machine/states.lua
+++ b/lib/ledge/state_machine/states.lua
@@ -386,7 +386,7 @@ return {
 
     purging = function(sm, handler)
         local mode = purge_mode()
-        local ok, message, job = purge(handler, mode)
+        local ok, message, job = purge(handler, mode, handler:cache_key_chain())
         local json = create_purge_response(mode, message, job)
         handler.response:set_body(json)
 

--- a/t/01-unit/purge.t
+++ b/t/01-unit/purge.t
@@ -256,3 +256,98 @@ location /cache {
 ]
 --- no_error_log
 [error]
+
+=== TEST 4: purge api
+--- http_config eval: $::HttpConfig
+--- config
+location /t {
+    rewrite ^ /cache4 break;
+    content_by_lua_block {
+        local handler = require("ledge").create_handler()
+        local redis   = require("ledge").create_redis_connection()
+        handler.redis = redis
+
+        local storage = require("ledge").create_storage_connection(
+                handler.config.storage_driver,
+                handler.config.storage_driver_config
+            )
+        handler.storage = storage
+
+        -- Stub out response object
+        local response = {
+            status = 0,
+            body,
+            set_body = function(self, body)
+                self.body = body
+            end
+        }
+        handler.response = response
+
+        local json_body = nil
+
+        ngx.req.get_body_data = function()
+            return json_body
+        end
+
+        local purge_api = require("ledge.purge").purge_api
+
+        -- Nil body
+        local ok, err = purge_api(handler)
+        if response.body then ngx.log(ngx.DEBUG, response.body) end
+        assert(ok == false and response.body ~= nil, "nil body should return false")
+        response.body = nil
+
+        -- Invalid json
+        json_body = [[ foobar  ]]
+        local ok, err = purge_api(handler)
+        if response.body then ngx.log(ngx.DEBUG, response.body) end
+        assert(ok == false and response.body ~= nil, "nil body should return false")
+        response.body = nil
+
+        -- Valid json, bad request
+        json_body = [[{"foo": "bar"}]]
+        local ok, err = purge_api(handler)
+        if response.body then ngx.log(ngx.DEBUG, response.body) end
+        assert(ok == false and response.body ~= nil, "nil body should return false")
+        response.body = nil
+
+        -- Valid API request
+        json_body = require("cjson").encode({
+            uris = {
+                "http://"..ngx.var.host..":"..ngx.var.server_port.."/cache4_prx"
+            },
+            purge_mode = "delete"
+        })
+        local ok, err = purge_api(handler)
+        if response.body then ngx.log(ngx.DEBUG, response.body) end
+        assert(ok == true and response.body ~= nil, "nil body should return false")
+        response.body = nil
+
+        local res, err = redis:exists(handler:cache_key_chain().main)
+        if err then ngx_log(ngx.ERR, err) end
+        assert(res == 0, "Key should have been removed")
+
+    }
+}
+location /cache4_prx {
+    rewrite ^(.*)_prx$ $1 break;
+    content_by_lua_block {
+        require("ledge.state_machine").set_debug(false)
+        local handler = require("ledge").create_handler()
+        handler:run()
+    }
+}
+
+location /cache {
+    content_by_lua_block {
+        ngx.header["Cache-Control"] = "max-age=4600"
+        ngx.say("TEST 4")
+    }
+}
+--- request eval
+[
+"GET /cache4_prx",
+"GET /t"
+]
+--- no_error_log
+[error]

--- a/t/01-unit/purge.t
+++ b/t/01-unit/purge.t
@@ -195,14 +195,12 @@ location /t {
         local purge = require("ledge.purge").purge
 
         -- invalidate - error
-        handler.cache_key_chain = function() return {main = "bogus_key"} end
-        local ok, err = purge(handler, "invalidate")
+        local ok, err = purge(handler, "invalidate", {main = "bogus_key"})
         if err then ngx.log(ngx.DEBUG, err) end
         assert(ok == false and err == "nothing to purge", "purge should return false - bad key")
-        handler.cache_key_chain = require("ledge.handler").cache_key_chain
 
         -- invalidate
-        local ok, err = purge(handler, "invalidate")
+        local ok, err = purge(handler, "invalidate", key_chain)
         if err then ngx.log(ngx.DEBUG, err) end
         assert(ok == true and err == "purged", "purge should return true - purged")
 
@@ -213,7 +211,7 @@ location /t {
             return "job"
         end
 
-        local ok, err, job = purge(handler, "revalidate")
+        local ok, err, job = purge(handler, "revalidate", key_chain)
         if err then ngx.log(ngx.DEBUG, err) end
         assert(ok == false and err == "already expired", "purge should return false - already expired")
         assert(reval_job == true, "revalidate should schedule job")
@@ -221,18 +219,18 @@ location /t {
 
         -- delete, error
         handler.delete_from_cache = function() return nil, "delete error" end
-        local ok, err = purge(handler, "delete")
+        local ok, err = purge(handler, "delete", key_chain)
         if err then ngx.log(ngx.DEBUG, err) end
         assert(ok == nil and err == "delete error", "purge should return nil, error")
         handler.delete_from_cache = require("ledge.handler").delete_from_cache
 
         -- delete
-        local ok, err = purge(handler, "delete")
+        local ok, err = purge(handler, "delete", key_chain)
         if err then ngx.log(ngx.DEBUG, err) end
         assert(ok == true and err == "deleted", "purge should return true - deleted")
 
         -- delete, missing
-        local ok, err = purge(handler, "delete")
+        local ok, err = purge(handler, "delete", key_chain)
         if err then ngx.log(ngx.DEBUG, err) end
         assert(ok == false and err == "nothing to purge", "purge should return false - nothing to purge")
     }

--- a/t/02-integration/purge.t
+++ b/t/02-integration/purge.t
@@ -887,7 +887,7 @@ location /purge_api {
 location /purge_cached_14_prx {
     rewrite ^(.*)_prx$ $1 break;
     content_by_lua_block {
-    require("ledge.state_machine").set_debug(false)
+        require("ledge.state_machine").set_debug(false)
         require("ledge").create_handler({
             keep_cache_for = 3600,
         }):run()
@@ -903,8 +903,8 @@ location /purge_cached_14 {
 [
 "GET /purge_cached_14_prx?a=1", "GET /purge_cached_14_prx?a=2",
 
-'PURGE /purge_api
-{"uris": ["http://localhost/purge_cached_14?a=1", "http://localhost/purge_cached_14?a=2"]}',
+qq(PURGE /purge_api
+{"uris": ["http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_14_prx?a=1", "http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_14_prx?a=2"]}),
 
 "GET /purge_cached_14_prx?a=1", "GET /purge_cached_14_prx?a=2",
 ]
@@ -918,10 +918,10 @@ location /purge_cached_14 {
 [
 "TEST 14: 1", "TEST 14: 2",
 
-"purge_mode: invalidate
-result.http://localhost/purge_cached_14?a=1.result: purged
-result.http://localhost/purge_cached_14?a=2.result: purged
-",
+qq(purge_mode: invalidate
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_14_prx?a=1.result: purged
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_14_prx?a=2.result: purged
+),
 
 "TEST 14: 1", "TEST 14: 2",
 ]
@@ -967,8 +967,8 @@ location /purge_cached_15 {
 [
 "GET /purge_cached_15_prx?a=1", "GET /purge_cached_15_prx?a=2",
 
-'PURGE /purge_api
-{"uris": ["http://localhost/purge_cached_15?a*"]}',
+qq(PURGE /purge_api
+{"uris": ["http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_15_prx?a*"]}),
 ]
 --- more_headers eval
 [
@@ -979,14 +979,14 @@ location /purge_cached_15 {
 [
 "TEST 15: 1", "TEST 15: 2",
 
-"purge_mode: invalidate
-result.http://localhost/purge_cached_15\\?a\\*.qless_job.jid: [a-f0-9]{32}
-result.http://localhost/purge_cached_15\\?a\\*.qless_job.klass: ledge.jobs.purge
-result.http://localhost/purge_cached_15\\?a\\*.qless_job.options.jid: [a-f0-9]{32}
-result.http://localhost/purge_cached_15\\?a\\*.qless_job.options.priority: 5
-result.http://localhost/purge_cached_15\\?a\\*.qless_job.options.tags.1: purge
-result.http://localhost/purge_cached_15\\?a\\*.result: scheduled
-",
+qq(purge_mode: invalidate
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_15_prx\\?a\\*.qless_job.jid: [a-f0-9]{32}
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_15_prx\\?a\\*.qless_job.klass: ledge.jobs.purge
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_15_prx\\?a\\*.qless_job.options.jid: [a-f0-9]{32}
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_15_prx\\?a\\*.qless_job.options.priority: 5
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_15_prx\\?a\\*.qless_job.options.tags.1: purge
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_15_prx\\?a\\*.result: scheduled
+),
 ]
 --- response_headers_like eval
 [
@@ -1038,7 +1038,7 @@ location /purge_api {
     }
 }
 location /purge_cached_16_prx {
-    rewrite ^(.*)_prx$ $1 break;
+    rewrite ^(.*)_prx(.*)? $1$2 break;
     content_by_lua_block {
     require("ledge.state_machine").set_debug(false)
         require("ledge").create_handler({
@@ -1056,8 +1056,8 @@ location /purge_cached_16 {
 [
 "GET /purge_cached_16_prx?a=1", "GET /purge_cached_16_prx?a=2",
 
-'PURGE /purge_api
-{"uris": ["http://localhost/purge*"]}',
+qq(PURGE /purge_api
+{"uris": ["http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_16_prx*"]}),
 ]
 --- more_headers eval
 [
@@ -1068,14 +1068,14 @@ location /purge_cached_16 {
 [
 "TEST 16: 1", "TEST 16: 2",
 
-"purge_mode: invalidate
-result.http://localhost/purge\\*.qless_job.jid: [a-f0-9]{32}
-result.http://localhost/purge\\*.qless_job.klass: ledge.jobs.purge
-result.http://localhost/purge\\*.qless_job.options.jid: [a-f0-9]{32}
-result.http://localhost/purge\\*.qless_job.options.priority: 5
-result.http://localhost/purge\\*.qless_job.options.tags.1: purge
-result.http://localhost/purge\\*.result: scheduled
-",
+qq(purge_mode: invalidate
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_16_prx\\*.qless_job.jid: [a-f0-9]{32}
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_16_prx\\*.qless_job.klass: ledge.jobs.purge
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_16_prx\\*.qless_job.options.jid: [a-f0-9]{32}
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_16_prx\\*.qless_job.options.priority: 5
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_16_prx\\*.qless_job.options.tags.1: purge
+result.http://localhost:$ENV{TEST_NGINX_PORT}/purge_cached_16_prx\\*.result: scheduled
+),
 ]
 --- response_headers_like eval
 [
@@ -1110,5 +1110,62 @@ location /purge_cached_16 {
 ["TEST 16b: 1", "TEST 16b: 2"]
 --- response_headers_like eval
 ["X-Cache: MISS from .+", "X-Cache: MISS from .+"]
+--- no_error_log
+[error]
+
+=== TEST 17: Purge API - bad request
+--- http_config eval: $::HttpConfig
+--- config
+location /purge_api {
+    content_by_lua_block {
+        require("ledge.state_machine").set_debug(true)
+        require("ledge").create_handler():run()
+    }
+   body_filter_by_lua_block {
+        ngx.arg[1] = format_json(ngx.arg[1])
+        ngx.arg[2] = true
+    }
+}
+
+--- request eval
+[
+'PURGE /purge_api
+{"uris": ["foobar"]}',
+
+'PURGE /purge_api
+this is not valid json',
+
+'PURGE /purge_api
+{"foo": ["bar"]}',
+
+'PURGE /purge_api
+{"uris": []}',
+
+'PURGE /purge_api
+{"uris": "not an array"}',
+
+'PURGE /purge_api
+{"uris": ["http://www.example.com/"], "purge_mode": "foobar"}'
+]
+--- more_headers
+Content-Type: Application/JSON
+--- error_code eval
+[200,400,400,400,400,400]
+--- response_body eval
+[
+"purge_mode: invalidate
+result.foobar.error: bad uri: foobar
+",
+"error: Could not parse request body: Expected value but found invalid token at character 1
+",
+"error: No URIs provided
+",
+"error: No URIs provided
+",
+"error: Field 'uris' must be an array
+",
+"error: Invalid purge_mode
+",
+]
 --- no_error_log
 [error]


### PR DESCRIPTION
Adds a JSON based purge API for purging multiple URIs at once.  

For each URI provided we make a loopback `PURGE` request to ourself.  
This approach allows for changing the `cache_key_spec` configuration in different nginx locations.  
Attempting to do the purging internally within the same request would use the key spec of the API request's only.

Additionally the following methods now require an explicit key chain argument rather than always using the handler instance's key chain
 * `handler.revalidate_in_background`
 * `handler.delete_from_cache`
 * `purge.purge`

Normal requests pass in `handler:cache_key_chain()` but wildcard purge jobs generate a key chain from the SCAN'd main key and pass that through directly.
Which removes the need to hack the handler key chain caching for each key.

Also removes some superfluous redis calls