### PR TITLE
Errors in coroutines

### DIFF
--- a/lib/ledge/util.lua
+++ b/lib/ledge/util.lua
@@ -1,8 +1,8 @@
 local ngx_var = ngx.var
 local ffi = require "ffi"
 
-local type, next, setmetatable, getmetatable, error, tostring, select =
-        type, next, setmetatable, getmetatable, error, tostring, select
+local type, next, setmetatable, getmetatable, error, tostring =
+        type, next, setmetatable, getmetatable, error, tostring
 
 local str_find = string.find
 local str_sub = string.sub
@@ -205,7 +205,13 @@ local function co_wrap(func)
     else
         return function(...)
             if co_status(co) == "suspended" then
-                return select(2, co_resume(co, ...))
+                -- Handle errors in coroutines
+                local ok, val1, val2, val3 = co_resume(co, ...)
+                if ok == true then
+                    return val1, val2, val3
+                else
+                    return nil, val1
+                end
             else
                 return nil, "can't resume a " .. co_status(co) .. " coroutine"
             end


### PR DESCRIPTION
Fixes #166 

`utils.co_wrap` will only return the first 3 yielded values now, so any filters that add extra return values will also have to increase that.

Implementing this with a flexible number of return values is both hard and requires a bunch of extra table creation / unpacking.