### PR TITLE
SSRF / XSS fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,23 @@ If `$(ESI_ARGS)` is used without a field key, it renders the original query stri
 
 [Back to TOC](#table-of-contents)
 
+
+### Variable Escaping
+
+ESI variables are minimally escaped by default in order to prevent user's injecting additional ESI tags or XSS exploits.
+
+Unescaped variables are available by prefixing the variable name with `RAW_`. This should be used with care.
+
+```html
+# /esi/test.html?a=<script>alert()</script>
+<esi:vars>
+$(QUERY_STRING{a})     <!-- &lt;script&gt;alert()&lt;/script&gt; -->
+$(RAW_QUERY_STRING{a}) <!--  <script>alert()</script> -->
+</esi:vars>
+```
+
+[Back to TOC](#table-of-contents)
+
 ### Missing ESI features
 
 The following parts of the [ESI specification](https://www.w3.org/TR/esi-lang) are not supported, but could be in due course if a need is identified.

--- a/lib/ledge/esi/processor_1_0.lua
+++ b/lib/ledge/esi/processor_1_0.lua
@@ -8,7 +8,7 @@ local   tostring, type, tonumber, next, unpack, pcall, setfenv =
 
 local str_sub = string.sub
 -- TODO: Find places we can use str_find over ngx_re_find
---local str_find = string.find
+local str_find = string.find
 
 local tbl_concat = table.concat
 local tbl_insert = table.insert
@@ -54,7 +54,7 @@ local esi_var_pattern =
 
 
 -- Evaluates a given ESI variable.
-local function esi_eval_var(var)
+local function _esi_eval_var(var)
     -- Extract variables from capture results table
     local var_name = var[1] or ""
 
@@ -142,6 +142,7 @@ local function esi_eval_var(var)
     else
         local custom_variables = ngx.ctx.__ledge_esi_custom_variables
         if next(custom_variables) then
+
             local var = custom_variables[var_name]
             if var then
                 if key then
@@ -161,6 +162,20 @@ local function esi_eval_var(var)
         end
         return default
     end
+end
+
+
+local function esi_eval_var(var)
+    var = _esi_eval_var(var)
+
+    -- Escape ESI tags in ESI variables
+    local pos = str_find(var, "<esi", 1, true)
+    if pos ~= nil then
+        var = ngx_re_gsub(var, "<", "&lt;", "soj")
+        var = ngx_re_gsub(var, ">", "&gt;", "soj")
+    end
+
+    return var
 end
 _M.esi_eval_var = esi_eval_var
 

--- a/t/01-unit/processor_1_0.t
+++ b/t/01-unit/processor_1_0.t
@@ -435,7 +435,7 @@ default
 ",
 ]
 
-=== TEST 9: esi_replace_vars
+=== TEST 9: esi_process_vars_tag
 --- http_config eval: $::HttpConfig
 --- config
 location /t {
@@ -480,9 +480,9 @@ location /t {
             },
         }
         for _, t in pairs(tests) do
-            local output = processor.esi_replace_vars(t["chunk"])
+            local output = processor.esi_process_vars_tag(t["chunk"])
             ngx.log(ngx.DEBUG, "'", output, "'")
-            assert(output == t["res"], "esi_replace_vars mismatch: "..t["msg"] )
+            assert(output == t["res"], "esi_process_vars_tag mismatch: "..t["msg"] )
         end
         ngx.say("OK")
     }

--- a/t/01-unit/processor_1_0.t
+++ b/t/01-unit/processor_1_0.t
@@ -453,6 +453,16 @@ location /t {
                 ["msg"]   = "vars tag"
             },
             {
+                ["chunk"] = [[before <esi:vars>$(QUERY_STRING)</esi:vars> after]],
+                ["res"]   = [[before test_param=test after]],
+                ["msg"]   = "vars tag - outside content"
+            },
+            {
+                ["chunk"] = [[before <esi:vars>$(QUERY_STRING) after</esi:vars>]],
+                ["res"]   = [[before test_param=test after]],
+                ["msg"]   = "vars tag - inside content"
+            },
+            {
                 ["chunk"] = [[   <esi:vars>   $(QUERY_STRING{test_param})   </esi:vars>   ]],
                 ["res"]   = [[      test      ]],
                 ["msg"]   = "vars tag - whitespace"

--- a/t/01-unit/processor_1_0.t
+++ b/t/01-unit/processor_1_0.t
@@ -442,28 +442,6 @@ location /t {
     content_by_lua_block {
         local processor = require("ledge.esi.processor_1_0")
         local tests = {
-        -- When tags
-            {
-                ["chunk"] = [[<esi:when test="$(QUERY_STRING{test_param})" >]],
-                ["res"]   = [[<esi:when test="'test'" >]],
-                ["msg"]   = "vars in when tag"
-            },
-            {
-                ["chunk"] = [[<esi:when   test="$(QUERY_STRING{test_param})"     >]],
-                ["res"]   = [[<esi:when   test="'test'"     >]],
-                ["msg"]   = "vars in when tag - whitespace"
-            },
-            {
-                ["chunk"] = [[<esi:when   test="$(QUERY_STRING{test_param})]],
-                ["res"]   = [[<esi:when   test="$(QUERY_STRING{test_param})]],
-                ["msg"]   = "vars in when tag - incomplete"
-            },
-            {
-                ["chunk"] = [[<esi:when test="$(QUERY_STRING{test_param})" == 'foobar'>]],
-                ["res"]   = [[<esi:when test="test" == 'foobar'>]],
-                ["msg"]   = "vars in when tag - quoting"
-            },
-
         -- vars tags
             {
                 ["chunk"] = [[<esi:vars>$(QUERY_STRING)</esi:vars>]],
@@ -490,14 +468,6 @@ location /t {
                 ["res"]   = [[<p>foo</p>]],
                 ["msg"]   = "empty vars tags removed - content preserved"
             },
-
-        -- other esi tags
-            {
-                ["chunk"] = [[<esi:foo>$(QUERY_STRING)</esi:foo>]],
-                ["res"]   = [[<esi:foo>test_param=test</esi:foo>]],
-                ["msg"]   = "foo tag"
-            },
-
         }
         for _, t in pairs(tests) do
             local output = processor.esi_replace_vars(t["chunk"])

--- a/t/01-unit/processor_1_0.t
+++ b/t/01-unit/processor_1_0.t
@@ -440,6 +440,10 @@ default
 --- config
 location /t {
     content_by_lua_block {
+        ngx.ctx.__ledge_esi_custom_variables = {
+
+            ["DANGER_ZONE"] = '<esi:include src="/kenny" />'
+        }
         local processor = require("ledge.esi.processor_1_0")
         local tests = {
         -- vars tags
@@ -468,6 +472,12 @@ location /t {
                 ["res"]   = [[<p>foo</p>]],
                 ["msg"]   = "empty vars tags removed - content preserved"
             },
+        --  injecting ESI tags from vars
+            {
+                ["chunk"] = [[<esi:vars>$(DANGER_ZONE)</esi:vars>]],
+                ["res"]   = [[&lt;esi:include src="/kenny" /&gt;]],
+                ["msg"]   = "Injected tags are escaped"
+            },
         }
         for _, t in pairs(tests) do
             local output = processor.esi_replace_vars(t["chunk"])
@@ -475,6 +485,11 @@ location /t {
             assert(output == t["res"], "esi_replace_vars mismatch: "..t["msg"] )
         end
         ngx.say("OK")
+    }
+}
+location /kenny {
+    content_by_lua_block {
+        ngx.print("Shouldn't see this")
     }
 }
 

--- a/t/01-unit/processor_1_0.t
+++ b/t/01-unit/processor_1_0.t
@@ -577,21 +577,29 @@ location /t {
                 ["res"]   = [[fragment]],
                 ["msg"]   = "nothing to escape"
             },
+            {
+                ["tag"] = [[<esi:include src="/frag?$(QUERY_STRING{test})" />]],
+                ["res"]   = [[fragmentfoobar]],
+                ["msg"]   = "Query string var is evaluated"
+            },
 
         }
         for _, t in pairs(tests) do
             local ret = processor.esi_fetch_include(self, t["tag"], buffer_size)
-            ngx.log(ngx.DEBUG, "'", output, "'")
+            ngx.log(ngx.DEBUG, "RET: '", ret, "'")
+            ngx.log(ngx.DEBUG, "OUTPUT: '", output, "'")
             assert(output == t["res"], "esi_fetch_include mismatch: "..t["msg"] )
         end
         ngx.say("OK")
     }
 }
 location /f {
-    content_by_lua_block { ngx.print("fragment") }
+    content_by_lua_block {
+        ngx.print("fragment", ngx.var.args or "")
+    }
 }
 --- request
-GET /t
+GET /t?test=foobar
 --- no_error_log
 [error]
 --- response_body

--- a/t/02-integration/esi.t
+++ b/t/02-integration/esi.t
@@ -1690,18 +1690,18 @@ Accept-Language: en-gb
 'repeat' != 'function'
 Failed
 ' repeat sentence with function in it ' == ' repeat sentence with function in it '
-hello == 'hello'
+$(QUERY_STRING{msg}) == 'hello'
 'string \' escaping' == 'string \' escaping'
 'string \" escaping' == 'string \" escaping'
-hel'lo == 'hel\'lo'
+$(QUERY_STRING{msg2}) == 'hel\'lo'
 'hello' =~ '/llo/'
 'HeL\'\'\'Lo' =~ '/hel[\']{1,3}lo/i'
 'http://example.com?foo=bar' =~ '/^(http[s]?)://([^:/]+)(?::(\d+))?(.*)/'
 Failed
 (1 > 2) | (3.02 > 2.4124 & 1 <= 1) && ('HeLLo' =~ '/hello/i')
 2 =~ '/[0-9]/'
-true == 'true'
-false == 'false'
+$(HTTP_ACCEPT_LANGUAGE{gb}) == 'true'
+$(HTTP_ACCEPT_LANGUAGE{fr}) == 'false'
 Failed
 
 


### PR DESCRIPTION
Prevent user-provided input (e.g. query strings) from injecting potentially malicious data.

Previously ESI variables were evaluated replaced in the response body *before* processing of ESI include or when/choose tags.  
This allowed the injection of new ESI tags and/or HTML directly into the response body.

ESI variables in ESI include and when/choose tags are now evaluated at the latest possible opportunity and never replaced within the response body.

Variables inside `<esi:vars>` tags could also inject new ESI tags or HTML into the response body allowing XSS attacks.

Now all variables have `<` and `>` characters replaced with their html entity equivalent *unless* the  variable name is prefixed with `RAW_`

e.g.

Escaped:
`<esi:vars>$(QUERY_STRING)</esi:vars>` 

Unescaped:
`<esi:vars>$(RAW_QUERY_STRING)</esi:vars>` 